### PR TITLE
Add missing step in setup instructions

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -90,6 +90,9 @@ gcloud secrets create broker-cookie-secret --replication-policy=automatic --data
 ```bash
 (cd setup && gcloud builds submit)
 ```
+```bash
+(cd setup/infra && gcloud builds submit)
+```
 
 2. Deploy the cluster for your desired region:
 


### PR DESCRIPTION
The setup instructions is missing a step to deploy the infrastructure at `setup/infra`, this pull request adds the following step when deploying the infrastructure:

```bash
(cd setup/infra && gcloud builds submit)
```